### PR TITLE
Add unit costs to relevant materials

### DIFF
--- a/data/magnet_materials.json
+++ b/data/magnet_materials.json
@@ -3,13 +3,30 @@
         "chemical_equation": "Nb3Sn",
         "density": 8.69,
         "density_unit": "g/cm3",
-        "percent_type": "ao"
+        "percent_type": "ao",
+        "unit_cost": 700
     },
-    "copper": {
+    "NbTi": {
+        "chemical_equation": "NbTi",
+        "density": 5.7,
+        "density_unit": "g/cm3",
+        "percent_type": "ao",
+        "unit_cost": 100
+    },
+    
+    "Copper": {
         "elements": {"Cu": 1.0},
         "density": 8.96,
         "density_unit": "g/cm3",
-        "percent_type": "ao"
+        "percent_type": "ao",
+        "unit_cost": 8.36
+    },
+    "Aluminum": {
+        "elements": {"Al": 1.0},
+        "density": 2.7,
+        "density_unit": "g/cm3",
+        "percent_type": "ao",
+        "unit_cost": 2.16
     },
     "ReBCO": {
         "elements": {
@@ -20,6 +37,7 @@
         },
         "density": 6.3,
         "density_unit": "g/cm3",
-        "percent_type": "ao"
+        "percent_type": "ao",
+        "unit_cost": 7000
     }
 }

--- a/data/multiplier_and_breeder_materials.json
+++ b/data/multiplier_and_breeder_materials.json
@@ -10,12 +10,14 @@
     },
     "lithium-lead": {
         "chemical_equation": "Pb842Li158",
-        "density": "99.90*(0.1-16.8e-6*(temperature - 273.15))",
+        "density_scaling": "99.90*(0.1-16.8e-6*(temperature - 273.15))",
+        "density": 9.15084, 
         "density_unit": "g/cm3",
         "comment": "density equation valid for in the range 240-350 C. source http://aries.ucsd.edu/LIB/PROPS/PANOS/lipb.html",
         "percent_type": "ao",
         "enrichment_target":"Li6",
-        "enrichment_type":"ao"
+        "enrichment_type":"ao",
+        "unit_cost": 25
     },
     "Li8PbO6": {
         "chemical_equation": "Li8PbO6",
@@ -29,12 +31,14 @@
     },
     "FLiBe": {
         "chemical_equation": "F2Li2BeF2",
-        "density": "2.214 - 4.2e-4 * (temperature - 273.15)",
+        "density_scaling": "2.214 - 4.2e-4 * (temperature - 273.15)",
+        "density": 2.004,
         "density_unit": "g/cm3",
         "comment": "source http://aries.ucsd.edu/LIB/MEETINGS/0103-TRANSMUT/gohar/Gohar-present.pdf",
         "percent_type": "ao",
         "enrichment_target":"Li6",
-        "enrichment_type":"ao"
+        "enrichment_type":"ao",
+        "unit_cost": 43
     },
     "FLiNaBe": {
         "chemical_equation": "FLiNaBe",

--- a/data/structural_materials.json
+++ b/data/structural_materials.json
@@ -47,7 +47,7 @@
         "comment": "neutronics handbook",
         "percent_type": "ao"
     },
-    "SS_316L_N_IG": {
+    "Steel, Stainless 316": {
         "elements": {
             "Fe": 62.973,
             "C": 0.030,
@@ -69,7 +69,8 @@
         "density": 7.93,
         "density_unit": "g/cm3",
         "comment": "neutronics handbook",
-        "percent_type": "ao"
+        "percent_type": "ao",
+        "unit_cost": 0.794
     },
     "tungsten_with_impurities": {
         "elements": {
@@ -110,14 +111,15 @@
         "percent_type": "ao",
         "comment": "https://physics.nist.gov/cgi-bin/Star/compos.pl?mode=text&matno=074"
     },
-    "tungsten": {
+    "Tungsten": {
         "elements": {
             "W": 1.0
         },
         "density": 19.3,
         "density_unit": "g/cm3",
         "percent_type": "ao", 
-        "comment": "https://physics.nist.gov/cgi-bin/Star/compos.pl?mode=text&matno=074"
+        "comment": "https://physics.nist.gov/cgi-bin/Star/compos.pl?mode=text&matno=074",
+        "unit_cost": 31.2
     },
     "P91": {
         "elements": {


### PR DESCRIPTION
See https://github.com/ProjectTorreyPines/FUSE.jl/pull/467 

Adds unit costs to relevant materials in dollars per kg to be used with densities to calculate unit costs in $/m^3. For materials with temperature-dependent densities (lithium-lead, FLiBe), I added the density at the fusion-relevant temperatures as a new field in the files. 