### PR TITLE
Improve/cached all materials

### DIFF
--- a/src/materials_utils.jl
+++ b/src/materials_utils.jl
@@ -23,6 +23,15 @@ function all_materials()
 end
 
 """
+    ALL_MATERIALS
+
+A constant that caches the result of calling `all_materials()`.
+This computation is performed only once when the module or script is loaded, so subsequent accesses simply retrieve the precomputed list.
+It returns a list of all unique materials supported by the `Material` function.
+"""
+const ALL_MATERIALS = all_materials()
+
+"""
     test_allowed_keywords(kw)
 
 Verifies if the keyword arguments provided (`kw`) are among the allowed environment keywords. Throws an assertion error if any keyword is not allowed.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using Test
 using FusionMaterials
-using IMAS
+import FusionMaterials.IMAS
 
 @testset "all_materials" begin
     for material_name in sort(FusionMaterials.all_materials())


### PR DESCRIPTION
## Issue
- The `all_materials()` function is relatively slow due to multiple `try`/`catch` blocks during method introspection.
  - Execution time can range from ~10–20 ms, and in some cases up to 100 ms.
- This function is a bottleneck when reading/loading the `ini` file.
  - e.g., `hdf2par` of single `ini.h5` calls `all_materials()` about 20 times
  
## Resolution

- Introduce a cached constant `ALL_MATERIALS` that stores the result of `all_materials()` so that it is computed only once.
- Replace `all_materials()` with `ALL_MATERIALS` in the `FUSE` results in:
  - about 9x faster `ini` loading.
     - single call of `hdf2par` takes from `200 ms` to `22 ms`
  - Overall, `load_database` becomes roughly 2–3x faster.

## Suggestion
- If the `Material` method is always defined in `FusionMaterials.jl`, we can consider defining `ALL_MATERIALS` first and then setting all_materials() to return `ALL_MATERIALS` like the followiong:
```julia
const ALL_MATERIALS begin
    materials = Symbol[]
    for m in methods(Material)
        try
            if m.sig.parameters[2] isa DataType && m.sig.parameters[2].parameters[1].name.name == :Val
                material = m.sig.parameters[2].parameters[1].parameters[1]
                push!(materials, material)
            end
        catch
            continue
        end
    end
    materials
end


all_materials() = ALL_MATERIALS
```


@TimSlendebroek 
I believe this change would be very helpful for reducing your pain when loading the database.